### PR TITLE
Catch the CurlExec Exception and restart the docker chrome container

### DIFF
--- a/lib/WebDriver/Session.php
+++ b/lib/WebDriver/Session.php
@@ -151,12 +151,31 @@ final class Session extends Container
      * Close session: /session/:sessionId (DELETE)
      *
      * @return mixed
+     * @throws Exception
      */
     public function close()
     {
-        $result = $this->curl('DELETE', '');
+        try {
+            $result = $this->curl('DELETE', '');
 
-        return $result['value'];
+            return $result['value'];
+        } catch (Exception $e) {
+            $containerName = 'chrome';
+            $container = exec("/usr/bin/docker ps --format '{{.Names}}' |  grep $containerName");
+
+            if (!strpos($container, $containerName)) {
+                //throw exception if chrome container not found, or docker not executable.
+                throw $e;
+            }
+
+            if (exec("/usr/bin/docker restart $container") !== $container) {
+                //throw exception if chrome container not restarted
+                throw $e;
+            }
+
+            return true;
+        }
+
     }
 
     // There's a limit to our ability to exploit the dynamic nature of PHP when it


### PR DESCRIPTION
This is the first part of 2 step fix for the `Curl timeout for Chrome DELETE API` issue

It will catch the `CurlExec` Exception when webdriver is trying to close the chrome session, then restart the chrome container instead.

Whatever container that running the PHP command need to apply another patch to make docker be able to run inside the container to restart another container. I will create a separate PR for that.